### PR TITLE
Use target index instead of generated uid

### DIFF
--- a/mrblib/icmp.rb
+++ b/mrblib/icmp.rb
@@ -11,7 +11,6 @@ class ICMPPinger
     @targets << [
       addr,
       opts.delete(:routing_table) || 0,
-      opts.delete(:uid) || 0,
       opts.delete(:interface),
       opts.delete(:source_address)
     ]
@@ -45,7 +44,7 @@ class ICMPPinger
     ret2 = {}
     
     # do the maths
-    ret1.each do |host, latencies|
+    ret1.each_with_index do |latencies, idx|
       sum = loss = 0
       latencies.each do |n|
         if n
@@ -55,6 +54,7 @@ class ICMPPinger
         end
       end
       
+      host = @targets[idx][0]
       # [host, sum / latencies.size(), (loss / latencies.size()) * 100]
       ret2[host] = [sum / latencies.size(), (loss / latencies.size()) * 100, {}]
       unless wanted_percentiles.empty?

--- a/src/mruby-ping.h
+++ b/src/mruby-ping.h
@@ -20,7 +20,6 @@ struct target_address {
   in_addr_t in_addr;
   in_addr_t in_addr_src;
   uint32_t  rtable;
-  uint16_t  uid;
 
 //#ifdef SO_BINDTODEVICE
   char      device[IFNAMSIZ];

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,22 @@
+pinger = ICMPPinger.new
+
+pinger.add_target('127.0.0.1')
+pinger.add_target('8.8.8.8')
+pinger.add_target('99.99.99.99')
+
+results = pinger.send_pings(1000, 8, 50, [0.95, 0.99])
+results.each do |host, res|
+  avg_time = res[0] > 0 ? "time #{res[0]}ms" : 'timeout'
+  lost = res[1]
+  percentiles = res[2].map { |perc, v| ", #{perc} - #{v}ms" }.join
+  puts "#{host}\n   #{avg_time}, #{lost}% lost#{percentiles}"
+end
+
+# # Sample output
+#
+# 127.0.0.1
+#    time 26.25ms, 0% lost, 0.95 - 62.6ms, 0.99 - 74.92ms
+# 8.8.8.8
+#    time 35766.875ms, 0% lost, 0.95 - 36591.85ms, 0.99 - 36846.37ms
+# 99.99.99.99
+#    timeout, 100% lost


### PR DESCRIPTION
It is more natural to use indexes, moreover everything is ready for that.

Also I changed higher level API to use hostname as hash key (I know it might be duplicates, but after all you are accepting strings as addresses, so duplicates are pretty obvious). Rakefile also referencing missing test.rb file, so I added one for reference.

If you don't like my commit with removing trailing spaces, I can exclude it from the list, but most of the editors (including mine) configured to strip them, so it would be a pain selecting patch hunks to not add those trailing spaces changes in the future.